### PR TITLE
Add difficulty level by stars

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Este projeto é uma **migração** do [UnoList](https://github.com/paulocastelo/
 * ✅ Função de reset total do banco (**Truncate**).
 * ✅ Garantia de que nenhuma tarefa fique sem categoria, com a categoria fixa **"Sem Categoria"** protegida contra remoção.
 * ✅ Sistema de pontuação por tarefas concluídas.
+* ✅ Níveis de dificuldade por estrelas (1 a 3).
 
 ---
 

--- a/lib/models/task.dart
+++ b/lib/models/task.dart
@@ -28,6 +28,9 @@ class Task extends HiveObject {
   @HiveField(7)
   DateTime createdAt;
 
+  @HiveField(8)
+  int level;
+
   /// 🚀 Construtor principal
   Task({
     required this.id, // Agora é String
@@ -38,6 +41,7 @@ class Task extends HiveObject {
     this.isCompleted = false,
     required this.priority,
     required this.createdAt,
+    this.level = 1,
   });
 
   /// 🏗️ Fábrica simplificada
@@ -48,6 +52,7 @@ class Task extends HiveObject {
     DateTime? dueDate,
     String? categoryId, // Muda aqui também para String?
     String priority = 'Média',
+    int level = 1,
   }) {
     return Task(
       id: id, // Recebe id já gerado
@@ -57,6 +62,7 @@ class Task extends HiveObject {
       categoryId: categoryId,
       isCompleted: false,
       priority: priority,
+      level: level,
       createdAt: DateTime.now(),
     );
   }
@@ -72,6 +78,7 @@ class Task extends HiveObject {
       'isCompleted': isCompleted,
       'priority': priority,
       'createdAt': createdAt.toIso8601String(),
+      'level': level,
     };
   }
 
@@ -88,6 +95,7 @@ class Task extends HiveObject {
       isCompleted: json['isCompleted'] ?? false,
       priority: json['priority'] ?? 'Média',
       createdAt: DateTime.parse(json['createdAt']),
+      level: json['level'] ?? 1,
     );
   }
 }

--- a/lib/models/task.g.dart
+++ b/lib/models/task.g.dart
@@ -25,13 +25,14 @@ class TaskAdapter extends TypeAdapter<Task> {
       isCompleted: fields[5] as bool,
       priority: fields[6] as String,
       createdAt: fields[7] as DateTime,
+      level: fields[8] as int,
     );
   }
 
   @override
   void write(BinaryWriter writer, Task obj) {
     writer
-      ..writeByte(8)
+      ..writeByte(9)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -47,7 +48,9 @@ class TaskAdapter extends TypeAdapter<Task> {
       ..writeByte(6)
       ..write(obj.priority)
       ..writeByte(7)
-      ..write(obj.createdAt);
+      ..write(obj.createdAt)
+      ..writeByte(8)
+      ..write(obj.level);
   }
 
   @override

--- a/lib/services/task_service.dart
+++ b/lib/services/task_service.dart
@@ -21,6 +21,7 @@ class TaskService {
     DateTime? dueDate,
     String? categoryId,
     String priority = 'Média',
+    int level = 1,
   }) async {
     final newTask = Task(
       id: const Uuid().v4(), // Gera um UUID
@@ -31,6 +32,7 @@ class TaskService {
       createdAt: DateTime.now(),
       isCompleted: false,
       priority: priority,
+      level: level,
     );
 
     await _box.put(newTask.id, newTask);

--- a/lib/ui/pages/home_page.dart
+++ b/lib/ui/pages/home_page.dart
@@ -200,6 +200,7 @@ class _HomePageState extends State<HomePage> {
               ? '${task.dueDate!.day}/${task.dueDate!.month}/${task.dueDate!.year}'
               : '',
           isCompleted: task.isCompleted,
+          level: task.level,
           onToggleComplete: () async {
             final wasCompleted = task.isCompleted;
             setState(() {

--- a/lib/ui/pages/task_form_page.dart
+++ b/lib/ui/pages/task_form_page.dart
@@ -37,6 +37,7 @@ class _TaskFormPageState extends State<TaskFormPage> {
   Category? selectedCategory;
   DateTime? selectedDate;
   bool isCompleted = false;
+  int level = 1;
 
   @override
   void initState() {
@@ -71,6 +72,7 @@ class _TaskFormPageState extends State<TaskFormPage> {
         }
         selectedDate = task.dueDate;
         isCompleted = task.isCompleted;
+        level = task.level;
       }
     });
   }
@@ -110,6 +112,7 @@ class _TaskFormPageState extends State<TaskFormPage> {
         dueDate: selectedDate,
         categoryId: selectedCategory?.id,
         priority: 'Média',
+        level: level,
       );
     } else {
       // ✏️ Edição
@@ -120,7 +123,8 @@ class _TaskFormPageState extends State<TaskFormPage> {
             : _descriptionController.text.trim()
         ..categoryId = selectedCategory?.id
         ..dueDate = selectedDate
-        ..isCompleted = isCompleted;
+        ..isCompleted = isCompleted
+        ..level = level;
 
       await _taskService.updateTask(updated);
     }
@@ -190,6 +194,25 @@ class _TaskFormPageState extends State<TaskFormPage> {
                     labelText: 'Title',
                     border: OutlineInputBorder(),
                   ),
+                ),
+                const SizedBox(height: 16),
+
+                // ⭐ Nível de dificuldade
+                Row(
+                  children: List.generate(3, (index) {
+                    final star = index + 1;
+                    return IconButton(
+                      icon: Icon(
+                        star <= level ? Icons.star : Icons.star_border,
+                        color: Colors.amber,
+                      ),
+                      onPressed: () {
+                        setState(() {
+                          level = star;
+                        });
+                      },
+                    );
+                  }),
                 ),
                 const SizedBox(height: 16),
 

--- a/lib/ui/widgets/task_item_widget.dart
+++ b/lib/ui/widgets/task_item_widget.dart
@@ -6,6 +6,7 @@ class TaskItemWidget extends StatelessWidget {
   final String category;
   final String date;
   final bool isCompleted;
+  final int level;
 
   final VoidCallback onToggleComplete;
   final VoidCallback onTap;
@@ -16,6 +17,7 @@ class TaskItemWidget extends StatelessWidget {
     required this.category,
     required this.date,
     required this.isCompleted,
+    required this.level,
     required this.onToggleComplete,
     required this.onTap,
   });
@@ -76,11 +78,24 @@ class TaskItemWidget extends StatelessWidget {
 
                       const SizedBox(width: 16),
 
-                      const Icon(Icons.calendar_today, size: 16),
-                      const SizedBox(width: 4),
-                      Text(date),
-                    ],
-                  ),
+                  const Icon(Icons.calendar_today, size: 16),
+                  const SizedBox(width: 4),
+                  Text(date),
+                ],
+              ),
+
+              const SizedBox(height: 4),
+
+              Row(
+                children: List.generate(3, (index) {
+                  final star = index + 1;
+                  return Icon(
+                    star <= level ? Icons.star : Icons.star_border,
+                    size: 16,
+                    color: Colors.amber,
+                  );
+                }),
+              ),
                 ],
               ),
             ),


### PR DESCRIPTION
## Summary
- store difficulty level in `Task`
- allow adding difficulty level in task form
- show stars for difficulty on task item widget
- handle difficulty parameter in task service and home page
- document star levels in README

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842b2edcd7c833286f3f0dd0eda6a5b